### PR TITLE
Fixed query string creation.

### DIFF
--- a/import
+++ b/import
@@ -6,7 +6,6 @@
 
 var readline = require('readline');
 var fs = require('fs');
-var querystring = require('querystring');
 
 var unirest = require('unirest');
 var natural = require('natural');

--- a/import
+++ b/import
@@ -73,12 +73,12 @@ var getRdioAlbums = function(config) {
 				name: rdioAlbumData.name,
 				artist: rdioAlbumData.artist,
 				upc: upc
-			});		
+			});
 		} catch (e) {
 			console.error('Error while parsing album JSON', e);
 		}
-		
 	});
+
 	var dfd = Q.defer();
 	dfd.resolve(albums);
 	return dfd.promise;
@@ -93,9 +93,9 @@ var getSpotifyAlbums = function(config, rdioAlbums) {
 	rdioAlbums.forEach(function(album) {
 		var albumDfd = Q.defer();
 		dfdList.push(albumDfd);
-		var query = 'album' + querystring.escape(':' + album.name) + '+artist' + querystring.escape(':' + album.artist);
+		var query = 'album:' + album.name + ' artist:' + album.artist;
 		if (album.upc) {
-			query = querystring.escape('upc:' + album.upc);
+			query = 'upc:' + album.upc;
 		}
 		var request = unirest
 			.get('https://api.spotify.com/v1/search')
@@ -168,7 +168,7 @@ var saveAlbumBatch = function(config, spotifyAlbumIds) {
 			if (!response.code == 201 || !response.code == 200) {
 				console.error('Error while saving album batch: "' + response.body.message + '"');
 			}
-		}); 
+		});
 };
 
 main();


### PR DESCRIPTION
Unirest escapes the query string, leading to faulty requests. Essentially, the % sign from the escaped string itself gets escaped in the unirest step.

Ex. if the album has UPC 00602547326645, then var query is `upc%3A00602547326645`; then once it is used in unirest what ends up being sent in the http request is `upc%253A00602547326645` because the % sign is being replaced by %25. Artist/album search queries were acting similarly.

To avoid the double-escaping, the query strings themselves are _not_ escaped, and unirest's escaping procedure therefore leads to the correct requests being made.
